### PR TITLE
Include puppeteer v2 in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^4.1.1"
   },
   "peerDependencies": {
-    "puppeteer": "^1.5.0"
+    "puppeteer": "^1.5.0 || ^2.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.4",


### PR DESCRIPTION
Updates the allowed versions of puppeteer to include v2 in the package.json peerDependencies.