### PR TITLE
Disable timeout option by setting to a large value

### DIFF
--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -158,6 +158,9 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
         if (this.options.perBrowserOptions) {
             this.perBrowserOptions = [...this.options.perBrowserOptions];
         }
+        if (this.options.timeout <= 0) {
+            this.options.timeout = Number.MAX_SAFE_INTEGER;
+        }
 
         try {
             await this.browser.init();


### PR DESCRIPTION
Fixes #190 and #166 

Sets the value of timeout in ClusterOptions to Number.MAX_SAFE_INTEGER in case it is set to a value less than or equal to 0. 