### PR TITLE
Added option to manually request browser restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "prepack": "npm i && npm run build",
     "test": "./node_modules/.bin/jest",
     "coverage": "./node_modules/.bin/jest --coverage",
     "dev": "./node_modules/.bin/tsc --watch",

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -472,6 +472,10 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
         debug('Closed');
     }
 
+    public requestRestart() {
+        this.browser?.requestRestart();
+    }
+
     private monitor(): void {
         if (!this.display) {
             this.display = new Display();

--- a/src/concurrency/ConcurrencyImplementation.ts
+++ b/src/concurrency/ConcurrencyImplementation.ts
@@ -37,6 +37,7 @@ export default abstract class ConcurrencyImplementation {
     public abstract async workerInstance(perBrowserOptions: LaunchOptions | undefined):
         Promise<WorkerInstance>;
 
+    public abstract requestRestart(): void;
 }
 
 /**

--- a/src/concurrency/SingleBrowserImplementation.ts
+++ b/src/concurrency/SingleBrowserImplementation.ts
@@ -60,6 +60,10 @@ export default abstract class SingleBrowserImplementation extends ConcurrencyImp
 
     protected abstract async freeResources(resources: ResourceData): Promise<void>;
 
+    requestRestart(): void {
+        this.repairRequested = true;
+    }
+
     public async workerInstance() {
         let resources: ResourceData;
 

--- a/src/concurrency/built-in/Browser.ts
+++ b/src/concurrency/built-in/Browser.ts
@@ -54,4 +54,6 @@ export default class Browser extends ConcurrencyImplementation {
         };
     }
 
+    requestRestart(): void {}
+
 }

--- a/test/Cluster.test.ts
+++ b/test/Cluster.test.ts
@@ -617,6 +617,9 @@ describe('options', () => {
                         repair: async () => {},
                     };
                 }
+
+                requestRestart(): void {
+                }
             }
 
             const cluster = await Cluster.launch({
@@ -715,6 +718,9 @@ describe('options', () => {
                         // full implementation
                         repair: async () => {},
                     };
+                }
+
+                requestRestart(): void {
                 }
             }
 


### PR DESCRIPTION
Option to request Cluster to restart the browser manually.
Motivation, sometimes when Google Chrome is running too long the RAM usage is increases.
Restart chrome from time to time (for example every 1k jobs) may be handy.
I added an implementation for that.
Restart may be handy for other reasons too. (Update some data from data dir ...)
Relevant mostly to to `SingleBrowserImplementation`
But as SingleBrowserImplementation extends ConcurrencyImplementation I couldn't find a way not to put it in the interface.

I tested It against my use case and it worked. 