### PR TITLE
Allow puppeteer version 4 and five

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "debug": "^4.1.1"
   },
   "peerDependencies": {
-    "puppeteer": "^1.5.0 || ^2.0.0 || ^3.0.0"
+    "puppeteer": "^1.5.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",


### PR DESCRIPTION
There are [latest versions](https://github.com/puppeteer/puppeteer/releases/tag/v5.2.1) for puppeteer