### PR TITLE
Add random delay to queries with sameDomainDelay set

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Emitted when a task is queued via [Cluster.queue] or [Cluster.execute]. The firs
   - `retryLimit` <[number]> How often do you want to retry a job before marking it as failed. Ignored by tasks queued via [Cluster.execute]. Defaults to `0`.
   - `retryDelay` <[number]> How much time should pass at minimum between the job execution and its retry. Ignored by tasks queued via [Cluster.execute]. Defaults to `0`.
   - `sameDomainDelay` <[number]> How much time should pass at minimum between two requests to the same domain. If you use this field, the queued `data` must be your URL or `data` must be an object containing a field called `url`.
+  - `sameDomainRandomness` <[number]> How much time should be added/subtracted to the `sameDomainDelay`. It will pick a random number between `-sameDomainRandomness` and `+sameDomainRandomness`. This option is ignored if `sameDomainDelay` is not set or if its value is higher than `sameDomainDelay`.
   - `skipDuplicateUrls` <[boolean]> If set to `true`, will skip URLs which were already crawled by the cluster. Defaults to `false`. If you use this field, the queued `data` must be your URL or `data` must be an object containing a field called `url`.
   - `timeout` <[number]> Specify a timeout for all tasks. Defaults to `30000` (30 seconds).
   - `monitor` <[boolean]> If set to `true`, will provide a small command line output to provide information about the crawling process. Defaults to `false`.

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -292,7 +292,7 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
             if (lastDomainAccess !== undefined
                 && lastDomainAccess + this.options.sameDomainDelay > Date.now()) {
                 this.jobQueue.push(job, {
-                    delayUntil: lastDomainAccess + this.options.sameDomainDelay + (Math.random() * this.options.sameDomainRandomness * 2) - this.options.sameDomainRandomness),
+                    delayUntil: lastDomainAccess + this.options.sameDomainDelay + (Math.random() * this.options.sameDomainRandomness * 2) - this.options.sameDomainRandomness,
                 });
                 this.work();
                 return;

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -27,6 +27,7 @@ interface ClusterOptions {
     retryDelay: number;
     skipDuplicateUrls: boolean;
     sameDomainDelay: number;
+    sameDomainRandomness: number;
     puppeteer: any;
 }
 
@@ -50,6 +51,7 @@ const DEFAULT_OPTIONS: ClusterOptions = {
     retryDelay: 0,
     skipDuplicateUrls: false,
     sameDomainDelay: 0,
+    sameDomainRandomness:0,
     puppeteer: undefined,
 };
 
@@ -286,7 +288,7 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
             if (lastDomainAccess !== undefined
                 && lastDomainAccess + this.options.sameDomainDelay > Date.now()) {
                 this.jobQueue.push(job, {
-                    delayUntil: lastDomainAccess + this.options.sameDomainDelay,
+                    delayUntil: lastDomainAccess + this.options.sameDomainDelay + (Math.random() * this.options.sameDomainRandomness * 2) - this.options.sameDomainRandomness),
                 });
                 this.work();
                 return;

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -163,6 +163,10 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
         if (this.options.perBrowserOptions) {
             this.perBrowserOptions = [...this.options.perBrowserOptions];
         }
+        
+        if (this.options.sameDomainDelay < this.options.sameDomainRandomness) {
+            this.options.sameDomainRandomness = 0;
+        }
 
         try {
             await this.browser.init();


### PR DESCRIPTION
Some websites have added detection for query frequency. If the delay between queries is regular, it will raise a flag. This option lets the user decide if a random delay (more or less the value set) should be applied to the standard delay.

Code AND doc have been updated to reflect this feature.