### PR TITLE
feat: add queue limit option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2021-02-23
+### Added
+- Add a new option `queueLimit` setting tasks limit in queue
+
 ## [0.22.0] - 2020-08-06
 ### Changed
 - Updated dependencies to their latest versions

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Emitted when a task is queued via [Cluster.queue] or [Cluster.execute]. The firs
 - `options` <[Object]> Set of configurable options for the cluster. Can have the following fields:
   - `concurrency` <*Cluster.CONCURRENCY_PAGE*|*Cluster.CONCURRENCY_CONTEXT*|*Cluster.CONCURRENCY_BROWSER*|ConcurrencyImplementation> The chosen concurrency model. See [Concurreny models](#concurreny-models) for more information. Defaults to `Cluster.CONCURRENCY_CONTEXT`. Alternatively you can provide a class implementing `ConcurrencyImplementation`.
   - `maxConcurrency` <[number]> Maximal number of parallel workers. Defaults to `1`.
+  - `queueLimit` <[number]> Maximal number of tasks in queue. Defaults to `Infinity`.
   - `puppeteerOptions` <[Object]> Object passed to [puppeteer.launch]. See puppeteer documentation for more information. Defaults to `{}`.
   - `perBrowserOptions` <[Array]<[Object]>> Object passed to [puppeteer.launch] for each individual browser. If set, `puppeteerOptions` will be ignored. Defaults to `undefined` (meaning that `puppeteerOptions` will be used).
   - `retryLimit` <[number]> How often do you want to retry a job before marking it as failed. Ignored by tasks queued via [Cluster.execute]. Defaults to `0`.

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -28,6 +28,7 @@ interface ClusterOptions {
     skipDuplicateUrls: boolean;
     sameDomainDelay: number;
     puppeteer: any;
+    queueLimit: number;
 }
 
 type Partial<T> = {
@@ -51,6 +52,7 @@ const DEFAULT_OPTIONS: ClusterOptions = {
     skipDuplicateUrls: false,
     sameDomainDelay: 0,
     puppeteer: undefined,
+    queueLimit: Infinity
 };
 
 interface TaskFunctionArguments<JobData> {
@@ -388,6 +390,10 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
         taskFunction?: TaskFunction<JobData, ReturnData>,
         callbacks?: ExecuteCallbacks,
     ): void {
+        if (this.jobQueue.size() + 1 > this.options.queueLimit) {
+            throw new Error('Queue limit reached')
+        }
+
         let realData: JobData | undefined;
         let realFunction: TaskFunction<JobData, ReturnData> | undefined;
         if (this.isTaskFunction(data)) {


### PR DESCRIPTION
This PR adds a new `queueLimit` option setting tasks limit in the queue.