### PR TITLE
Use correct `options` when repairing using `CONCURRENCY_BROWSER`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepack": "npm i && npm run build",
     "test": "./node_modules/.bin/jest",
     "coverage": "./node_modules/.bin/jest --coverage",
     "dev": "./node_modules/.bin/tsc --watch",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
+    "prepack": "npm i && npm run build",
     "test": "./node_modules/.bin/jest",
     "coverage": "./node_modules/.bin/jest --coverage",
     "dev": "./node_modules/.bin/tsc --watch",

--- a/src/concurrency/built-in/Browser.ts
+++ b/src/concurrency/built-in/Browser.ts
@@ -49,7 +49,7 @@ export default class Browser extends ConcurrencyImplementation {
                 } catch (e) {}
 
                 // just relaunch as there is only one page per browser
-                chrome = await this.puppeteer.launch(this.options);
+                chrome = await this.puppeteer.launch(options);
             },
         };
     }


### PR DESCRIPTION
When using `perBrowserOptions` and `CONCURRENCY_BROWSER`, a browser repair sequence will currently pass the `Browser.options` member into `Browser.puppeteer.launch` instead of the proper `options` local variable that was used to initially launch the browser. This means the puppeteer browser options will silently switch to the defaults if the chrome instance ever crashes.

This PR simply swaps out the variable for the correct one.