### PR TITLE
should catch worker handle error

### DIFF
--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -322,7 +322,9 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
             (jobFunction as TaskFunction<JobData, ReturnData>),
             job,
             this.options.timeout,
-        );
+        ).catch((err) => {
+            return { type: 'error', error: err };
+        });
 
         if (result.type === 'error') {
             if (job.executeCallbacks) {


### PR DESCRIPTION
If some error occurs inside the worker.handle(), the worker will always be in busy.