### PR TITLE
fix: export type about cluster 

### DIFF
--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -15,7 +15,7 @@ import ConcurrencyImplementation, { WorkerInstance, ConcurrencyImplementationCla
 
 const debug = util.debugGenerator('Cluster');
 
-interface ClusterOptions {
+export interface ClusterOptions {
     concurrency: number | ConcurrencyImplementationClassType;
     maxConcurrency: number;
     workerCreationDelay: number;
@@ -34,7 +34,7 @@ type Partial<T> = {
     [P in keyof T]?: T[P];
 };
 
-type ClusterOptionsArgument = Partial<ClusterOptions>;
+export type ClusterOptionsArgument = Partial<ClusterOptions>;
 
 const DEFAULT_OPTIONS: ClusterOptions = {
     concurrency: 2, // CONTEXT

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-
 export { default as Cluster } from './Cluster';
+export { TaskFunction, ClusterOptions, ClusterOptionsArgument } from './Cluster'


### PR DESCRIPTION
I want to write function like this example. 
But TaskFunction, Cluster Options,, etc are not exported. 

```
export const finder: TaskFunction<RenderOptions, RenderResult> = async ({ page, data }) => { 

}
```