### PR TITLE
Add new event taskinprogress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.x.x] - [xxxx-xx-xx]
+### Added
+- Added new event 'taskinprogress'.
+
 ## [0.24.0] - 2024-03-17
 Note: Use a version older than `0.24.0` if you want to use a puppeteer version older than 22.0.0.
 ### Changed

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ In case the task was queued via [Cluster.execute] there will be no event fired.
 
 Emitted when a task is queued via [Cluster.queue] or [Cluster.execute]. The first argument is the object containing the data (if any data is provided). The second argument is the queued function (if any). In case only a function is provided via [Cluster.queue] or [Cluster.execute], the first argument will be undefined. If only data is provided, the second argument will be undefined.
 
+#### event: 'taskinprogress'
+- <\?[Object]>
+- <\?[boolean]>
+
+Emitted when a task that was queued starts execution. This event is emitted when a job is shifted from the queue. The first argument is the object containing the data (if any is provided). The second argument indicates whether the execution is a callback or not.
+
 #### Cluster.launch(options)
 - `options` <[Object]> Set of configurable options for the cluster. Can have the following fields:
   - `concurrency` <*Cluster.CONCURRENCY_PAGE*|*Cluster.CONCURRENCY_CONTEXT*|*Cluster.CONCURRENCY_BROWSER*|ConcurrencyImplementation> The chosen concurrency model. See [Concurreny models](#concurreny-models) for more information. Defaults to `Cluster.CONCURRENCY_CONTEXT`. Alternatively you can provide a class implementing `ConcurrencyImplementation`.

--- a/src/Cluster.ts
+++ b/src/Cluster.ts
@@ -13,6 +13,7 @@ import { EventEmitter } from 'events';
 import ConcurrencyImplementation, { WorkerInstance, ConcurrencyImplementationClassType }
     from './concurrency/ConcurrencyImplementation';
 
+
 const debug = util.debugGenerator('Cluster');
 
 interface ClusterOptions {
@@ -262,6 +263,9 @@ export default class Cluster<JobData = any, ReturnData = any> extends EventEmitt
         }
 
         const job = this.jobQueue.shift();
+
+        const isCallbackExecution = !!job?.executeCallbacks;
+        this.emit("taskinprogress", job?.data, isCallbackExecution);
 
         if (job === undefined) {
             // skip, there are items in the queue but they are all delayed


### PR DESCRIPTION
### Why was this implemented?

This was implemented to make it possible to identify a task that is in progress. Currently, it is possible to identify an error and also if a task has been added to the queue. However, in situations where it is necessary to manage the 'progress' of tasks for database management, for example, it becomes somewhat complex.

### How does it work?

```typescript
cluster.on("taskinprogress", (data, isCallbackExecution) => {
    if (isCallbackExecution) {
        console.log("A callback is in progress");
    } else {
        console.log("A task is in progress and it is not a callback");
    }
});

```
###  Tests

- A test similar to the event queue test has been implemented.

### Readme
 - The file `README.md` was updated

### Missing
  - `CONTRIBUTING.md` don't contains version and date release.
  - The `package-json` don't contain this version.