### PR TITLE
feat: Export certain types in order to create custom concurrency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,9 @@
 
 export { default as Cluster } from './Cluster';
+export { timeoutExecute, debugGenerator } from './util';
+export {
+    default as ConcurrencyImplementation,
+    type WorkerInstance,
+    type ResourceData,
+    type JobInstance,
+} from './concurrency/ConcurrencyImplementation';


### PR DESCRIPTION
Although "Custom concurrency" is currently experimental, it would be helpful to have a base type defined in order to enable any meaningful use. Additionally, functions related to logging should be exposed to maintain compatibility with the package.